### PR TITLE
feat: add option for custom message

### DIFF
--- a/src/ShipitSmarter.Core/Exceptions/NotFoundException.cs
+++ b/src/ShipitSmarter.Core/Exceptions/NotFoundException.cs
@@ -27,6 +27,16 @@ public class NotFoundException : DomainException
     /// <summary>
     /// Initializes a new instance of the <see cref="NotFoundException"/>
     /// </summary>
+    /// <param name="id">An identifier which is the identifier of the resource that was not found</param>
+    /// <param name="message">Custom message that precedes the identifier</param>
+    public NotFoundException(string id, string message) : base($"{message} {id}.")
+    {
+        StatusCode = 404;
+    }
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotFoundException"/>
+    /// </summary>
     /// <typeparam name="T">Type of the object that was not found</typeparam>
     /// <param name="id">An identifier which is the identifier of the resource that was not found</param>
     public static NotFoundException ForType<T>(string id) => new(id, typeof(T));

--- a/src/ShipitSmarter.Core/Exceptions/NotFoundException.cs
+++ b/src/ShipitSmarter.Core/Exceptions/NotFoundException.cs
@@ -28,8 +28,8 @@ public class NotFoundException : DomainException
     /// Initializes a new instance of the <see cref="NotFoundException"/>
     /// </summary>
     /// <param name="message">A composite format string, like in string.Format()</param>
-    /// <param name="args">An object array that contains one or more objects to format.</param>
-    public NotFoundException(string message, params object?[] args) : base(string.Format(message, args))
+    /// <param name="args">A string array that contains one or more strings to format.</param>
+    public NotFoundException(string message, params string[] args) : base(string.Format(message, args))
     {
         StatusCode = 404;
     }

--- a/src/ShipitSmarter.Core/Exceptions/NotFoundException.cs
+++ b/src/ShipitSmarter.Core/Exceptions/NotFoundException.cs
@@ -27,9 +27,9 @@ public class NotFoundException : DomainException
     /// <summary>
     /// Initializes a new instance of the <see cref="NotFoundException"/>
     /// </summary>
-    /// <param name="id">An identifier which is the identifier of the resource that was not found</param>
-    /// <param name="message">Custom message that precedes the identifier</param>
-    public NotFoundException(string id, string message) : base($"{message} {id}.")
+    /// <param name="message">A composite format string, like in string.Format()</param>
+    /// <param name="args">An object array that contains one or more objects to format.</param>
+    public NotFoundException(string message, params object?[] args) : base(string.Format(message, args))
     {
         StatusCode = 404;
     }


### PR DESCRIPTION
- add option for custom message 
  - in _shipping_, we implemented _search_ methods that need Not Found responses like: `Could not find shipment for reference [reference].`, which falls outside of current implementable NotFoundException possibilities.