### PR TITLE
feat: add logic for local DateTime and absolute DateTimeOffset

### DIFF
--- a/src/ShipitSmarter.Core/Converters/MandatoryTimeZoneDateTimeOffsetConverter.cs
+++ b/src/ShipitSmarter.Core/Converters/MandatoryTimeZoneDateTimeOffsetConverter.cs
@@ -37,6 +37,6 @@ public class MandatoryTimeZoneDateTimeOffsetConverter : JsonConverter<DateTimeOf
     /// <param name="options"></param>
     public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
     {
-        JsonSerializer.Serialize(writer, value, options);
+        JsonSerializer.Serialize(writer, value);
     }
 }

--- a/src/ShipitSmarter.Core/Converters/MandatoryTimeZoneDateTimeOffsetConverter.cs
+++ b/src/ShipitSmarter.Core/Converters/MandatoryTimeZoneDateTimeOffsetConverter.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ShipitSmarter.Core.Converters;
+
+/// <summary>
+/// Custom JsonConverter to enforce time zone specification for DateTimeOffset
+/// </summary>
+public class MandatoryTimeZoneDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+{
+    /// <summary>
+    /// Throws an exception if the DateTimeOffset has no time zone specification
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <param name="typeToConvert"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    /// <exception cref="JsonException"></exception>
+    public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var dateTime = DateTime.Parse(reader.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+        if (dateTime.Kind != DateTimeKind.Utc)
+        {
+            throw new JsonException("Time zone specification for DateTimeOffset is mandatory");
+        }
+        var dateTimeOffset = DateTimeOffset.Parse(reader.GetString()!, CultureInfo.InvariantCulture);
+        
+        return dateTimeOffset;
+    }
+
+    /// <summary>
+    /// Default implementation
+    /// </summary>
+    /// <param name="writer"></param>
+    /// <param name="value"></param>
+    /// <param name="options"></param>
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, options);
+    }
+}

--- a/src/ShipitSmarter.Core/Converters/NoTimeZoneAllowedDateTimeConverter.cs
+++ b/src/ShipitSmarter.Core/Converters/NoTimeZoneAllowedDateTimeConverter.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ShipitSmarter.Core.Converters;
+
+/// <summary>
+/// Custom JsonConverter to prevent time zone specification for DateTime
+/// </summary>
+public class NoTimeZoneAllowedDateTimeConverter : JsonConverter<DateTime>
+{
+    /// <summary>
+    /// Throws an exception if the DateTime has a time zone specification
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <param name="typeToConvert"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    /// <exception cref="JsonException"></exception>
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        
+        var dateTime = DateTime.Parse(reader.GetString()!, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+        if (dateTime.Kind == DateTimeKind.Utc)
+        {
+            throw new JsonException("Time zone specification for DateTime is not allowed");
+        }
+
+        return dateTime;
+    }
+
+    /// <summary>
+    /// Default implementation
+    /// </summary>
+    /// <param name="writer"></param>
+    /// <param name="value"></param>
+    /// <param name="options"></param>
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, options);
+    }
+}

--- a/src/ShipitSmarter.Core/Converters/NoTimeZoneAllowedDateTimeConverter.cs
+++ b/src/ShipitSmarter.Core/Converters/NoTimeZoneAllowedDateTimeConverter.cs
@@ -37,6 +37,6 @@ public class NoTimeZoneAllowedDateTimeConverter : JsonConverter<DateTime>
     /// <param name="options"></param>
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
     {
-        JsonSerializer.Serialize(writer, value, options);
+        JsonSerializer.Serialize(writer, value);
     }
 }

--- a/src/ShipitSmarter.Core/Documentation/AbsoluteDateTimeOffsetSchemaFilter.cs
+++ b/src/ShipitSmarter.Core/Documentation/AbsoluteDateTimeOffsetSchemaFilter.cs
@@ -1,0 +1,25 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace ShipitSmarter.Core.Documentation;
+
+/// <summary>
+/// Swagger filter to add a clarification to DateTime schema to indicate that it is not allowed to specify a time zone
+/// </summary>
+public class AbsoluteDateTimeOffsetSchemaFilter : ISchemaFilter
+{
+    /// <summary>
+    /// Adds a clarification to DateTime schema to indicate that it is not allowed to specify a time zone
+    /// </summary>
+    /// <param name="schema"></param>
+    /// <param name="context"></param>
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.Type != typeof(DateTimeOffset) && context.Type != typeof(DateTimeOffset?))
+        {
+            return;
+        }
+
+        schema.Description += ". NOTE: Time zone specification is mandatory";
+    }
+}

--- a/src/ShipitSmarter.Core/Documentation/LocalDateTimeSchemaFilter.cs
+++ b/src/ShipitSmarter.Core/Documentation/LocalDateTimeSchemaFilter.cs
@@ -1,0 +1,26 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace ShipitSmarter.Core.Documentation;
+
+
+/// <summary>
+/// Swwagger filter to add a clarification to DateTime schema to indicate that it is not allowed to specify a time zone
+/// </summary>
+public class LocalDateTimeSchemaFilter : ISchemaFilter
+{
+    /// <summary>
+    /// Adds a clarification to DateTime schema to indicate that it is not allowed to specify a time zone
+    /// </summary>
+    /// <param name="schema"></param>
+    /// <param name="context"></param>
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (context.Type != typeof(DateTime) && context.Type != typeof(DateTime?))
+        {
+            return;
+        }
+
+        schema.Description += ". NOTE: Time zone specification is not allowed";
+    }
+}

--- a/src/ShipitSmarter.Core/ShipitSmarter.Core.csproj
+++ b/src/ShipitSmarter.Core/ShipitSmarter.Core.csproj
@@ -46,6 +46,8 @@
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+      <PackageReference Include="Microsoft.OpenApi" Version="1.6.9" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
       <PackageReference Include="System.Text.Json" Version="7.0.3" />
       <PackageReference Include="YamlDotNet" Version="13.2.0" />
     </ItemGroup>

--- a/test/ShipitSmarter.Core.Tests/Converters/MandatoryTimeZoneDateTimeOffsetConverterTests.cs
+++ b/test/ShipitSmarter.Core.Tests/Converters/MandatoryTimeZoneDateTimeOffsetConverterTests.cs
@@ -27,8 +27,8 @@ public class MandatoryTimeZoneDateTimeOffsetConverterTests
         var testClass = JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options);
         Assert.Equal(new DateTimeOffset(2021, 9, 1, 0, 0, 0, TimeSpan.FromHours(2)), testClass!.DateTimeOffset);
         
-        // var backToString = JsonSerializer.Serialize(testClass, _options);
-        // Assert.Equal(Wrap(dateTimeString), backToString);
+        var backToString = JsonSerializer.Serialize(testClass, _options);
+        Assert.Equal(Wrap(dateTimeString), backToString);
     }
     
     [Fact]
@@ -38,6 +38,9 @@ public class MandatoryTimeZoneDateTimeOffsetConverterTests
         
         var testClass = JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options);
         Assert.Equal(new DateTimeOffset(2021, 9, 1, 0, 0, 0, TimeSpan.Zero), testClass!.DateTimeOffset);
+        
+        var backToString = JsonSerializer.Serialize(testClass, _options);
+        Assert.Equal(Wrap(dateTimeString), backToString);
     }
 
     private string Wrap(string dateTimeString)

--- a/test/ShipitSmarter.Core.Tests/Converters/MandatoryTimeZoneDateTimeOffsetConverterTests.cs
+++ b/test/ShipitSmarter.Core.Tests/Converters/MandatoryTimeZoneDateTimeOffsetConverterTests.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using ShipitSmarter.Core.Converters;
+
+namespace ShipitSmarter.Core.Tests.Converters;
+
+public class MandatoryTimeZoneDateTimeOffsetConverterTests
+{
+    private readonly JsonSerializerOptions _options = new()
+    {
+        Converters = { new MandatoryTimeZoneDateTimeOffsetConverter() }
+    };
+
+    [Fact]
+    public void Read_WithDateTimeOffsetWithoutTimeZone_ThrowsJsonException()
+    {
+        var dateTimeString = "2021-09-01T00:00:00";
+        
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options));
+        Assert.Equal("Time zone specification for DateTimeOffset is mandatory", exception.Message);
+    }
+    
+    [Fact]
+    public void Read_WithDateTimeOffsetWithTimeZone_ReturnsDateTimeOffset()
+    {
+        var dateTimeString = "2021-09-01T00:00:00+02:00";
+        
+        var testClass = JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options);
+        Assert.Equal(new DateTimeOffset(2021, 9, 1, 0, 0, 0, TimeSpan.FromHours(2)), testClass!.DateTimeOffset);
+        
+        // var backToString = JsonSerializer.Serialize(testClass, _options);
+        // Assert.Equal(Wrap(dateTimeString), backToString);
+    }
+    
+    [Fact]
+    public void Read_WithDateTimeOffsetWithUtcTimeZone_ReturnsDateTimeOffset()
+    {
+        var dateTimeString = "2021-09-01T00:00:00Z";
+        
+        var testClass = JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options);
+        Assert.Equal(new DateTimeOffset(2021, 9, 1, 0, 0, 0, TimeSpan.Zero), testClass!.DateTimeOffset);
+    }
+
+    private string Wrap(string dateTimeString)
+    {
+        return @"{""DateTimeOffset"":""" + dateTimeString + @"""}";
+    }
+    
+    [Serializable]
+    private record TestClass(DateTimeOffset DateTimeOffset);
+}

--- a/test/ShipitSmarter.Core.Tests/Converters/MandatoryTimeZoneDateTimeOffsetConverterTests.cs
+++ b/test/ShipitSmarter.Core.Tests/Converters/MandatoryTimeZoneDateTimeOffsetConverterTests.cs
@@ -19,28 +19,19 @@ public class MandatoryTimeZoneDateTimeOffsetConverterTests
         Assert.Equal("Time zone specification for DateTimeOffset is mandatory", exception.Message);
     }
     
-    [Fact]
-    public void Read_WithDateTimeOffsetWithTimeZone_ReturnsDateTimeOffset()
+    [Theory]
+    [InlineData("2021-09-01T00:00:00+02:00", 2, "2021-09-01T00:00:00+02:00")]
+    [InlineData("2021-09-01T00:00:00Z", 0, "2021-09-01T00:00:00+00:00")]
+    public void Read_WithDateTimeOffsetWithTimeZone_ReturnsDateTimeOffset(string dateTimeString, int offSet, string expectedSerializedDateTimeOffset)
     {
-        var dateTimeString = "2021-09-01T00:00:00+02:00";
+        var expectedTimeSpan = offSet == 0 ? TimeSpan.Zero : TimeSpan.FromHours(offSet);
+        var expectedDateTimeOffset = new DateTimeOffset(2021, 9, 1, 0, 0, 0, expectedTimeSpan);
         
         var testClass = JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options);
-        Assert.Equal(new DateTimeOffset(2021, 9, 1, 0, 0, 0, TimeSpan.FromHours(2)), testClass!.DateTimeOffset);
+        Assert.Equal(expectedDateTimeOffset, testClass!.DateTimeOffset);
         
         var backToString = JsonSerializer.Serialize(testClass, _options);
-        Assert.Equal(Wrap(dateTimeString), backToString);
-    }
-    
-    [Fact]
-    public void Read_WithDateTimeOffsetWithUtcTimeZone_ReturnsDateTimeOffset()
-    {
-        var dateTimeString = "2021-09-01T00:00:00Z";
-        
-        var testClass = JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options);
-        Assert.Equal(new DateTimeOffset(2021, 9, 1, 0, 0, 0, TimeSpan.Zero), testClass!.DateTimeOffset);
-        
-        var backToString = JsonSerializer.Serialize(testClass, _options);
-        Assert.Equal(Wrap(dateTimeString), backToString);
+        Assert.Equal(Wrap(expectedSerializedDateTimeOffset), backToString);
     }
 
     private string Wrap(string dateTimeString)

--- a/test/ShipitSmarter.Core.Tests/Converters/NoTimeZoneAllowedDateTimeConverterTests.cs
+++ b/test/ShipitSmarter.Core.Tests/Converters/NoTimeZoneAllowedDateTimeConverterTests.cs
@@ -9,7 +9,7 @@ public class NoTimeZoneAllowedDateTimeConverterTests
     {
         Converters = { new NoTimeZoneAllowedDateTimeConverter() }
     };
-    
+
     [Theory]
     [InlineData("2021-09-01T00:00:00+02:00")]
     [InlineData("2021-09-01T00:00:00Z")]
@@ -27,8 +27,8 @@ public class NoTimeZoneAllowedDateTimeConverterTests
         var testClass = JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options);
         Assert.Equal(new DateTime(2021, 9, 1, 0, 0, 0, DateTimeKind.Utc), testClass!.DateTime);
         
-        // var backToString = JsonSerializer.Serialize(testClass, _options);
-        // Assert.Equal(Wrap(dateTimeString), backToString);
+        var backToString = JsonSerializer.Serialize(testClass, _options);
+        Assert.Equal(Wrap(dateTimeString), backToString);
     }
     
     private string Wrap(string dateTimeString)

--- a/test/ShipitSmarter.Core.Tests/Converters/NoTimeZoneAllowedDateTimeConverterTests.cs
+++ b/test/ShipitSmarter.Core.Tests/Converters/NoTimeZoneAllowedDateTimeConverterTests.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using ShipitSmarter.Core.Converters;
+
+namespace ShipitSmarter.Core.Tests.Converters;
+
+public class NoTimeZoneAllowedDateTimeConverterTests
+{
+    private readonly JsonSerializerOptions _options = new()
+    {
+        Converters = { new NoTimeZoneAllowedDateTimeConverter() }
+    };
+    
+    [Theory]
+    [InlineData("2021-09-01T00:00:00+02:00")]
+    [InlineData("2021-09-01T00:00:00Z")]
+    public void Read_WithDateTimeWithTimeZone_ThrowsJsonException(string dateTimeString)
+    {
+        var exception = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options));
+        Assert.Equal("Time zone specification for DateTime is not allowed", exception.Message);
+    }
+    
+    [Fact]
+    public void Read_WithDateTimeWithUtcTimeZone_ReturnsDateTime()
+    {
+        var dateTimeString = "2021-09-01T00:00:00";
+        
+        var testClass = JsonSerializer.Deserialize<TestClass>(Wrap(dateTimeString), _options);
+        Assert.Equal(new DateTime(2021, 9, 1, 0, 0, 0, DateTimeKind.Utc), testClass!.DateTime);
+        
+        // var backToString = JsonSerializer.Serialize(testClass, _options);
+        // Assert.Equal(Wrap(dateTimeString), backToString);
+    }
+    
+    private string Wrap(string dateTimeString)
+    {
+        return @"{""DateTime"":""" + dateTimeString + @"""}";
+    }
+    
+    [Serializable]
+    private record TestClass(DateTime DateTime);
+}


### PR DESCRIPTION
- Add custom JsonConverter to enforce time zone specification in DateTimeOffset
- Add custom JsonConverter to prevent time zone specification in DateTime
- Add custom Swagger schema filter to specify for each DateTime that time zone specification is not allowed
- Add custom Swagger schema filter to specify for each DateTimeOffset that time zone specification is mandatory
- Add SwashBuckle.SwaggerGen Nuget package
- Add Microsoft.OpenAPI Nuget package