### PR TITLE
SmartEnum updates

### DIFF
--- a/src/ShipitSmarter.Core/ShipitSmarter.Core.csproj
+++ b/src/ShipitSmarter.Core/ShipitSmarter.Core.csproj
@@ -39,7 +39,7 @@
 
 
     <ItemGroup>
-      <PackageReference Include="Ardalis.SmartEnum" Version="7.0.0" />
+      <PackageReference Include="Ardalis.SmartEnum" Version="2.1.0" />
       <PackageReference Include="JsonSchema.Net" Version="4.1.1" />
       <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />


### PR DESCRIPTION
- downgrade smartenum nuget to 2.1.0
- Update `SmartEnumDocumentFilter`: smart search for correct type schema