### PR TITLE
Ensures DateTimes are serialized without timezone notation

### DIFF
--- a/src/ShipitSmarter.Core.Serialization/Converters/NoTimeZoneAllowedDateTimeConverter.cs
+++ b/src/ShipitSmarter.Core.Serialization/Converters/NoTimeZoneAllowedDateTimeConverter.cs
@@ -37,6 +37,7 @@ public class NoTimeZoneAllowedDateTimeConverter : JsonConverter<DateTime>
     /// <param name="options"></param>
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
     {
-        JsonSerializer.Serialize(writer, value);
+        var unspecifiedDateTime = DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
+        JsonSerializer.Serialize(writer, unspecifiedDateTime);
     }
 }


### PR DESCRIPTION
We enforce rules that all `DateTime` objects must be of kind `unspecified` upon deserialization. But do not adhere to our own rules when serializing.

In shipping we ran into an issue where we would `GET` a shipment contract, modify a single field, and then `PUT` the same object back. 
The deserialization code threw an error since the DateTime object had a `Z` for `UTC` added at the end. 

This change marks all DateTimes as `Unspecified` before serializing to JSON