### PR TITLE
feat: Add property compare attributes

### DIFF
--- a/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/GreaterThanAttribute.cs
+++ b/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/GreaterThanAttribute.cs
@@ -1,0 +1,11 @@
+namespace ShipitSmarter.Core.DataAnnotations;
+
+/// <summary>
+/// Validates that this value is greater than the value of another property.
+/// </summary>
+public class GreaterThanAttribute : PropertyComparerAttribute
+{
+    /// <inheritdoc/>
+    public GreaterThanAttribute(string dependentProperty) : base(Operator.GreaterThan, dependentProperty)
+    { }
+}

--- a/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/GreaterThanOrEqualAttribute.cs
+++ b/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/GreaterThanOrEqualAttribute.cs
@@ -1,0 +1,11 @@
+namespace ShipitSmarter.Core.DataAnnotations;
+
+/// <summary>
+/// Validates that this value is greater than or equal the value of another property.
+/// </summary>
+public class GreaterThanOrEqualAttribute : PropertyComparerAttribute
+{
+    /// <inheritdoc/>
+    public GreaterThanOrEqualAttribute(string dependentProperty) : base(Operator.GreaterThanOrEqualTo, dependentProperty)
+    { }
+}

--- a/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/LessThanAttribute.cs
+++ b/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/LessThanAttribute.cs
@@ -1,0 +1,11 @@
+namespace ShipitSmarter.Core.DataAnnotations;
+
+/// <summary>
+/// Validates that this value is less than the value of another property.
+/// </summary>
+public class LessThanAttribute : PropertyComparerAttribute
+{
+    /// <inheritdoc/>
+    public LessThanAttribute(string dependentProperty) : base(Operator.LessThan, dependentProperty)
+    { }
+}

--- a/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/LessThanOrEqualAttribute.cs
+++ b/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/LessThanOrEqualAttribute.cs
@@ -1,0 +1,11 @@
+namespace ShipitSmarter.Core.DataAnnotations;
+
+/// <summary>
+/// Validates that this value is less than or equal to the value of another property.
+/// </summary>
+public class LessThanOrEqualAttribute : PropertyComparerAttribute
+{
+    /// <inheritdoc/>
+    public LessThanOrEqualAttribute(string dependentProperty) : base(Operator.LessThanOrEqualTo, dependentProperty)
+    { }
+}

--- a/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/Operator.cs
+++ b/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/Operator.cs
@@ -1,0 +1,11 @@
+namespace ShipitSmarter.Core.DataAnnotations;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+public enum Operator
+{
+    GreaterThan,
+    GreaterThanOrEqualTo,
+    LessThan,
+    LessThanOrEqualTo,
+}
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/OperatorValidator.cs
+++ b/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/OperatorValidator.cs
@@ -22,7 +22,7 @@ internal class OperatorValidator
                     IsValid = (value, dependentValue) => {
                         if (value is null || dependentValue is null)
                             return false;
-                        return ((IComparable)value).CompareTo((IComparable)dependentValue) >= 1;
+                        return Compare(value, dependentValue) >= 1;
                     }
                 }
             },
@@ -35,7 +35,7 @@ internal class OperatorValidator
                             return true;
                         if (value is null || dependentValue is null)
                             return false;
-                        return ((IComparable)value).CompareTo((IComparable)dependentValue) >= 0;
+                        return Compare(value, dependentValue) >= 0;
                     }
                 }
             },
@@ -46,7 +46,7 @@ internal class OperatorValidator
                     IsValid = (value, dependentValue) => {
                         if (value is null || dependentValue is null)
                             return false;
-                        return ((IComparable)value).CompareTo((IComparable)dependentValue) <= -1;
+                        return Compare(value, dependentValue) <= -1;
                     }
                 }
             },
@@ -59,10 +59,18 @@ internal class OperatorValidator
                             return true;
                         if (value is null || dependentValue is null)
                             return false;
-                        return ((IComparable)value).CompareTo((IComparable)dependentValue) <= 0;
+                        return Compare(value, dependentValue) <= 0;
                     }
                 }
             },
         };
+    }
+
+    private static int Compare(object value, object dependentValue)
+    {
+        var comparableValue = (IComparable)value;
+        var comparableDependentValue = (IComparable)dependentValue;
+
+        return comparableValue.CompareTo(comparableDependentValue);
     }
 }

--- a/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/OperatorValidator.cs
+++ b/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/OperatorValidator.cs
@@ -1,0 +1,68 @@
+namespace ShipitSmarter.Core.DataAnnotations;
+
+internal class OperatorValidator
+{
+    public string ErrorMessage { get; internal set; } = string.Empty;
+    public Func<object, object, bool> IsValid { get; internal set; } = (_, _) => true;
+
+    static OperatorValidator()
+    {
+        InitialiseOperators();
+    }
+
+    public static Dictionary<Operator, OperatorValidator> Operators = [];
+
+    private static void InitialiseOperators()
+    {
+        Operators = new Dictionary<Operator, OperatorValidator>()
+        {
+            { Operator.GreaterThan, new OperatorValidator()
+                {
+                    ErrorMessage = "greater than",
+                    IsValid = (value, dependentValue) => {
+                        if (value is null || dependentValue is null)
+                            return false;
+                        return ((IComparable)value).CompareTo((IComparable)dependentValue) >= 1;
+                    }
+                }
+            },
+
+            { Operator.GreaterThanOrEqualTo, new OperatorValidator()
+                {
+                    ErrorMessage = "greater than or equal to",
+                    IsValid = (value, dependentValue) => {
+                        if (value is null && dependentValue is null)
+                            return true;
+                        if (value is null || dependentValue is null)
+                            return false;
+                        return ((IComparable)value).CompareTo((IComparable)dependentValue) >= 0;
+                    }
+                }
+            },
+
+            { Operator.LessThan, new OperatorValidator()
+                {
+                    ErrorMessage = "less than",
+                    IsValid = (value, dependentValue) => {
+                        if (value is null || dependentValue is null)
+                            return false;
+                        return ((IComparable)value).CompareTo((IComparable)dependentValue) <= -1;
+                    }
+                }
+            },
+
+            { Operator.LessThanOrEqualTo, new OperatorValidator()
+                {
+                    ErrorMessage = "less than or equal to",
+                    IsValid = (value, dependentValue) => {
+                        if (value is null && dependentValue is null)
+                            return true;
+                        if (value is null || dependentValue is null)
+                            return false;
+                        return ((IComparable)value).CompareTo((IComparable)dependentValue) <= 0;
+                    }
+                }
+            },
+        };
+    }
+}

--- a/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/PropertyComparerAttribute.cs
+++ b/src/ShipitSmarter.Core/DataAnnotations/PropertyComparers/PropertyComparerAttribute.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+
+namespace ShipitSmarter.Core.DataAnnotations;
+
+/// <summary>
+/// Base class for attributes that compare to a value of another property.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class PropertyComparerAttribute : ValidationAttribute
+{
+    private readonly string _dependentProperty;
+    private readonly OperatorValidator _validator;
+
+    /// <inheritdoc/>
+    public PropertyComparerAttribute(Operator @operator, string dependentProperty)
+    {
+        _dependentProperty = dependentProperty;
+        _validator = OperatorValidator.Operators[@operator];
+    }
+
+    /// <inheritdoc/>
+    public override bool RequiresValidationContext => true;
+
+    /// <inheritdoc/>
+    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    {
+        var dependentPropertyInfo = validationContext.ObjectType.GetProperty(_dependentProperty);
+        if (dependentPropertyInfo is null) {
+            return new ValidationResult(string.Format(CultureInfo.CurrentCulture, "The type '{0}' does not contain a public property named '{1}'.", validationContext.ObjectType, _dependentProperty));
+        }
+
+        var dependentValue = dependentPropertyInfo.GetValue(validationContext.ObjectInstance, null);
+        if (!_validator.IsValid(value, dependentValue)) {
+            return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+        }
+
+        return ValidationResult.Success;
+    }
+
+    private string DefaultErrorMessage => $"{{0}} must be {_validator.ErrorMessage} {{1}}.";
+
+    /// <inheritdoc/>
+    public override string FormatErrorMessage(string name)
+    {
+        if (string.IsNullOrEmpty(ErrorMessageResourceName) && string.IsNullOrEmpty(ErrorMessage))
+        {
+            ErrorMessage = DefaultErrorMessage;
+        }
+
+        return string.Format(ErrorMessageString, name, _dependentProperty);
+    }
+}

--- a/test/ShipitSmarter.Core.Tests/DataAnnotations/GreaterThanAttributeTests.cs
+++ b/test/ShipitSmarter.Core.Tests/DataAnnotations/GreaterThanAttributeTests.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using ShipitSmarter.Core.DataAnnotations;
+
+namespace ShipitSmarter.Core.Tests.DataAnnotations;
+
+public class GreaterThanAttributeTester
+{
+    public int MinIntProperty { get; set; }
+    [GreaterThan(nameof(MinIntProperty))]
+    public int MaxIntProperty { get; set; }
+
+    public decimal MinDecimalProperty { get; set; }
+    [GreaterThan(nameof(MinDecimalProperty))]
+    public decimal MaxDecimalProperty { get; set; }
+
+    public DateTime MinDateTimeProperty { get; set; }
+    [GreaterThan(nameof(MinDateTimeProperty))]
+    public DateTime MaxDateTimeProperty { get; set; }
+}
+
+public class GreaterThanAttributeTests
+{
+    [Fact]
+    public void TryValidate_GreaterThan_ShouldReturnTrue()
+    {
+        var tester = new GreaterThanAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 100,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 167.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2024, 1, 5),
+        };
+
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), [], validateAllProperties: true);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryValidate_Equal_ShouldReturnFalse()
+    {
+        var tester = new GreaterThanAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 50,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 25.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2023, 12, 11),
+        };
+
+        var results = new List<ValidationResult>();
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), results, validateAllProperties: true);
+
+        result.Should().BeFalse();
+        results.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void TryValidate_LessThan_ShouldReturnFalse()
+    {
+        var tester = new GreaterThanAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 40,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 20.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2020, 10, 5),
+        };
+
+        var results = new List<ValidationResult>();
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), results, validateAllProperties: true);
+
+        result.Should().BeFalse();
+        results.Should().HaveCount(3);
+    }
+}

--- a/test/ShipitSmarter.Core.Tests/DataAnnotations/GreaterThanOrEqualAttributeTests.cs
+++ b/test/ShipitSmarter.Core.Tests/DataAnnotations/GreaterThanOrEqualAttributeTests.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using ShipitSmarter.Core.DataAnnotations;
+
+namespace ShipitSmarter.Core.Tests.DataAnnotations;
+
+public class GreaterThanOrEqualAttributeTester
+{
+    public int MinIntProperty { get; set; }
+    [GreaterThanOrEqual(nameof(MinIntProperty))]
+    public int MaxIntProperty { get; set; }
+
+    public decimal MinDecimalProperty { get; set; }
+    [GreaterThanOrEqual(nameof(MinDecimalProperty))]
+    public decimal MaxDecimalProperty { get; set; }
+
+    public DateTime MinDateTimeProperty { get; set; }
+    [GreaterThanOrEqual(nameof(MinDateTimeProperty))]
+    public DateTime MaxDateTimeProperty { get; set; }
+}
+
+public class GreaterThanOrEqualAttributeTests
+{
+    [Fact]
+    public void TryValidate_GreaterThan_ShouldReturnTrue()
+    {
+        var tester = new GreaterThanOrEqualAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 100,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 167.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2024, 1, 5),
+        };
+
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), [], validateAllProperties: true);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryValidate_Equal_ShouldReturnTrue()
+    {
+        var tester = new GreaterThanOrEqualAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 50,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 25.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2023, 12, 11),
+        };
+
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), [], validateAllProperties: true);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryValidate_LessThan_ShouldReturnFalse()
+    {
+        var tester = new GreaterThanOrEqualAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 40,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 20.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2020, 10, 5),
+        };
+
+        var results = new List<ValidationResult>();
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), results, validateAllProperties: true);
+
+        result.Should().BeFalse();
+        results.Should().HaveCount(3);
+    }
+}

--- a/test/ShipitSmarter.Core.Tests/DataAnnotations/LessThanAttributeTests.cs
+++ b/test/ShipitSmarter.Core.Tests/DataAnnotations/LessThanAttributeTests.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using ShipitSmarter.Core.DataAnnotations;
+
+namespace ShipitSmarter.Core.Tests.DataAnnotations;
+
+public class LessThanAttributeTester
+{
+    public int MinIntProperty { get; set; }
+    [LessThan(nameof(MinIntProperty))]
+    public int MaxIntProperty { get; set; }
+
+    public decimal MinDecimalProperty { get; set; }
+    [LessThan(nameof(MinDecimalProperty))]
+    public decimal MaxDecimalProperty { get; set; }
+
+    public DateTime MinDateTimeProperty { get; set; }
+    [LessThan(nameof(MinDateTimeProperty))]
+    public DateTime MaxDateTimeProperty { get; set; }
+}
+
+public class LessThanAttributeTests
+{
+    [Fact]
+    public void TryValidate_GreaterThan_ShouldReturnFalse()
+    {
+        var tester = new LessThanAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 100,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 167.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2024, 1, 5),
+        };
+
+        var results = new List<ValidationResult>();
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), results, validateAllProperties: true);
+
+        result.Should().BeFalse();
+        results.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void TryValidate_Equal_ShouldReturnFalse()
+    {
+        var tester = new LessThanAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 50,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 25.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2023, 12, 11),
+        };
+
+        var results = new List<ValidationResult>();
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), results, validateAllProperties: true);
+
+        result.Should().BeFalse();
+        results.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void TryValidate_LessThan_ShouldReturnTrue()
+    {
+        var tester = new LessThanAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 40,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 20.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2020, 10, 5),
+        };
+
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), [], validateAllProperties: true);
+
+        result.Should().BeTrue();
+    }
+}

--- a/test/ShipitSmarter.Core.Tests/DataAnnotations/LessThanOrEqualAttributeTests.cs
+++ b/test/ShipitSmarter.Core.Tests/DataAnnotations/LessThanOrEqualAttributeTests.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using ShipitSmarter.Core.DataAnnotations;
+
+namespace ShipitSmarter.Core.Tests.DataAnnotations;
+
+public class LessThanOrEqualAttributeTester
+{
+    public int MinIntProperty { get; set; }
+    [LessThanOrEqual(nameof(MinIntProperty))]
+    public int MaxIntProperty { get; set; }
+
+    public decimal MinDecimalProperty { get; set; }
+    [LessThanOrEqual(nameof(MinDecimalProperty))]
+    public decimal MaxDecimalProperty { get; set; }
+
+    public DateTime MinDateTimeProperty { get; set; }
+    [LessThanOrEqual(nameof(MinDateTimeProperty))]
+    public DateTime MaxDateTimeProperty { get; set; }
+}
+
+public class LessThanOrEqualAttributeTests
+{
+    [Fact]
+    public void TryValidate_GreaterThan_ShouldReturnFalse()
+    {
+        var tester = new LessThanOrEqualAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 100,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 167.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2024, 1, 5),
+        };
+
+        var results = new List<ValidationResult>();
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), results, validateAllProperties: true);
+
+        result.Should().BeFalse();
+        results.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void TryValidate_Equal_ShouldReturnTrue()
+    {
+        var tester = new LessThanOrEqualAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 50,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 25.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2023, 12, 11),
+        };
+
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), [], validateAllProperties: true);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryValidate_LessThan_ShouldReturnTrue()
+    {
+        var tester = new LessThanOrEqualAttributeTester()
+        {
+            MinIntProperty = 50,
+            MaxIntProperty = 40,
+
+            MinDecimalProperty = 25.5M,
+            MaxDecimalProperty = 20.5M,
+
+            MinDateTimeProperty = new(2023, 12, 11),
+            MaxDateTimeProperty = new(2020, 10, 5),
+        };
+
+        var result = Validator.TryValidateObject(tester, new ValidationContext(tester), [], validateAllProperties: true);
+
+        result.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Adds a set of attributes that can be used to validate that a property has a value greater / less than the value of another property. Useful for, for example, validating a that the End property of a range is greater than the Begin property.